### PR TITLE
Fix stochastic oscillator k_period argument

### DIFF
--- a/merged_production_rl_bot - LLMs.py
+++ b/merged_production_rl_bot - LLMs.py
@@ -1555,7 +1555,7 @@ class AdvancedFeatureEngineer:
         # Stochastic Oscillator with symbol-specific parameters
         stoch_params = config["stoch_params"]
         stoch = StochasticOscillator(df["high"], df["low"], df["close"], 
-                                   window=stoch_params["k"], k_period=stoch_params["k"], d_period=stoch_params["d"])
+                                   window=stoch_params["k"], smooth_window=stoch_params["d"])
         df["stoch_k"] = stoch.stoch()
         df["stoch_d"] = stoch.stoch_signal()
         df["stoch_oversold"] = (df["stoch_k"] < 20).astype(int)


### PR DESCRIPTION
Correct `StochasticOscillator` initialization parameters to resolve `TypeError`.

The `StochasticOscillator` from the `ta` library expects `window` for the K period and `smooth_window` for the D period, not `k_period` or `d_period`.

---
<a href="https://cursor.com/background-agent?bcId=bc-4b04d9ed-10eb-4600-a073-aafd6148e5d1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4b04d9ed-10eb-4600-a073-aafd6148e5d1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

